### PR TITLE
Correction de Gradle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,12 +28,12 @@ android {
     ndkVersion flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17' // Essayez '17', si ça ne marche pas, revenez à '11' ou '1.8'
     }
 
     sourceSets {
@@ -41,10 +41,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.lvlmindbeta"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
@@ -53,8 +50,6 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,9 +8,7 @@ buildscript {
     }
 
     dependencies {
-        // ANCIEN : classpath 'com.android.tools.build:gradle:7.3.0'
-        // NOUVEAU : Mettre à jour vers une version compatible avec Java 21 et Gradle 8.14
-        classpath 'com.android.tools.build:gradle:8.4.0' // <-- MODIFIÉ ICI
+        classpath 'com.android.tools.build:gradle:8.4.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-all.zip

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -292,10 +292,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "317a5d961cec5b34e777b9252393f2afbd23084aa6e60fcf601dcf6341b9ebeb"
+      sha256: "6fae381e6af2bbe0365a5e4ce1db3959462fa0c4d234facf070746024bb80c8d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12+23"
+    version: "0.8.12+24"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -681,10 +681,10 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher
-      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.3.2"
   url_launcher_android:
     dependency: transitive
     description:


### PR DESCRIPTION
This pull request updates the Android build configuration to use newer versions of Java, Gradle, and related tools, ensuring compatibility with modern development standards. Key changes include upgrading Java and Gradle versions, modifying Kotlin JVM target compatibility, and cleaning up outdated comments in the Gradle configuration files.

### Build configuration updates:

* Updated `sourceCompatibility` and `targetCompatibility` in `android/app/build.gradle` to Java 17, and set `kotlinOptions.jvmTarget` to `17` with a fallback suggestion in the comment. (`[android/app/build.gradleL31-L47](diffhunk://#diff-9526ccfd1d1813ed49c39f8c54dbeb512607376a007d824b905bc8b4e4d202d9L31-L47)`)
* Updated the Gradle wrapper distribution URL in `android/gradle/wrapper/gradle-wrapper.properties` to use Gradle version 8.8. (`[android/gradle/wrapper/gradle-wrapper.propertiesL5-R5](diffhunk://#diff-4c5ffadbdf6016477a1c3768e0b7381cc298bd558b1784871f407cbcb0efacceL5-R5)`)

### Dependency updates:

* Updated the Android Gradle plugin version to `8.4.0` in `android/build.gradle`. (`[android/build.gradleL11-R11](diffhunk://#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65aL11-R11)`)

### Cleanup:

* Removed outdated comments in `android/app/build.gradle` related to signing configurations and application ID setup. (`[android/app/build.gradleL56-L57](diffhunk://#diff-9526ccfd1d1813ed49c39f8c54dbeb512607376a007d824b905bc8b4e4d202d9L56-L57)`)