### PR TITLE
Maj

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -785,18 +785,18 @@ packages:
     dependency: transitive
     description:
       name: video_player_android
-      sha256: "4a5135754a62dbc827a64a42ef1f8ed72c962e191c97e2d48744225c2b9ebb73"
+      sha256: "0fabf59eea728a6a887f29f2818eafbefb4b37c727dbb62dccef56c9287a692f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.7"
+    version: "2.8.10"
   video_player_avfoundation:
     dependency: transitive
     description:
       name: video_player_avfoundation
-      sha256: "9fedd55023249f3a02738c195c906b4e530956191febf0838e37d0dac912f953"
+      sha256: d716c279c940b5b4625da6bae625e88540d4150a8f3390f961454245e9848675
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.0"
+    version: "2.8.1"
   video_player_platform_interface:
     dependency: transitive
     description:


### PR DESCRIPTION
This pull request introduces a new configuration file, `devtools_options.yaml`, to store settings for Dart & Flutter DevTools. It includes a description and a link to relevant documentation.

* New configuration file:
  * [`devtools_options.yaml`](diffhunk://#diff-74b02520cb30233ed12dff30d25e25e1f9af8bb932111444d30f0d47b0b77957R1-R3): Added a new file to store settings for Dart & Flutter DevTools, including a description and a link to documentation for configuring extension enablement states.